### PR TITLE
Correct dead Google Code URL and fix tests

### DIFF
--- a/e4u/__init__.py
+++ b/e4u/__init__.py
@@ -12,14 +12,14 @@ import symbol
 _loader = None
 
 def load(filename=None,
-        url=r"http://emoji4unicode.googlecode.com/svn/trunk/data/emoji4unicode.xml",
+        url=r"https://raw.githubusercontent.com/googlei18n/emoji4unicode/master/data/emoji4unicode.xml",
         loader_class=None):
     u"""load google's `emoji4unicode` project's xml file. must call this method first to use `e4u` library. this method never work twice if you want to reload, use `e4u.reload()` insted."""
     if not has_loaded():
         reload(filename, url, loader_class)
         
 def reload(filename=None,
-        url=r"http://emoji4unicode.googlecode.com/svn/trunk/data/emoji4unicode.xml",
+        url=r"https://raw.githubusercontent.com/googlei18n/emoji4unicode/master/data/emoji4unicode.xml",
         loader_class=None):
     u"""reload google's `emoji4unicode` project's xml file. must call this method first to use `e4u` library."""
     if loader_class is None:

--- a/e4u/loader.py
+++ b/e4u/loader.py
@@ -32,7 +32,7 @@ class Loader(object):
         self._translate_dictionaries = create_translate_dictionaries(self.symbols)
         
         
-    def load(self, filename=None, url=r"http://emoji4unicode.googlecode.com/svn/trunk/data/emoji4unicode.xml"):
+    def load(self, filename=None, url=r"https://raw.githubusercontent.com/googlei18n/emoji4unicode/master/data/emoji4unicode.xml"):
         if filename:
             xml = open(filename, 'r').read()
         else:

--- a/test/test.py
+++ b/test/test.py
@@ -7,6 +7,8 @@
 import unittest
 import e4u
 
+e4u.load()
+
 DISPLAY_INFO = False
 
 class TestCaseAbstract(object):


### PR DESCRIPTION
Since Google Code is down, the hard coded URL won't work anymore, so it should be changed to the one on Github. The tests also won't run, as the init will fail due import.